### PR TITLE
Be Python 3.x-compatible and respect xpath index access methods

### DIFF
--- a/json_lxml.py
+++ b/json_lxml.py
@@ -2,6 +2,7 @@
 """convert between python value and lxml.etree so that lxml's power can be applied to json data.
 In particular, xpath queries can be run against json.
 """
+import sys
 from lxml import etree
 
 type_map = dict(
@@ -25,7 +26,7 @@ def element(k, v):
     if isinstance(v, dict):
         for ck, cv in v.items():
             node.append(element(ck, cv))
-    elif isinstance(v, unicode):
+    elif sys.version_info < (3,0,0) and isinstance(v, unicode):
         node.set('type', type(v).__name__)
         node.text=v.encode('utf8')
     elif isinstance(v, (int, float, bool, str, NoneType)):  # scalar

--- a/json_lxml.py
+++ b/json_lxml.py
@@ -35,7 +35,7 @@ def element(k, v):
     elif isinstance(v, list):
         node.set('type', type(v).__name__)  # list xx this could be done across the board.
         for i, cv in enumerate(v):
-            node.append(element("_list_element_%d" % i, cv))
+            node.append(element("item", cv))
     else:
         assert False
 


### PR DESCRIPTION
unicode is undefined in python 3, as everything is unicode there. There are no defined unit tests, so I am not nicely able to test for 2.x-compatibility.
